### PR TITLE
Structure fog code

### DIFF
--- a/shaders/gbuffers_basic.fsh
+++ b/shaders/gbuffers_basic.fsh
@@ -18,24 +18,10 @@ varying vec2 texcoord;
 
 void main()
 {
-    //if(texcoord.x < 1 / viewWidth && texcoord.y < 1 / viewHeight) discard;
-
     vec4 col = color;
 
-    //Calculate fog intensity in or out of water.
-    //vec4 fog = vec4(1);
-    //fog.a = gl_Fog.scale;
-    vec4 fog;
-    if(fogMode == GL_EXP)
-        fog.a = 1.-exp(-gl_FogFragCoord * gl_Fog.density);
-    else if (fogMode == GL_LINEAR)
-        fog.a = clamp((gl_FogFragCoord-gl_Fog.start) * gl_Fog.scale, 0., 1.);
-    else if (isEyeInWater == 1.0 || isEyeInWater == 2.0)
-        fog.a = 1.-exp(-gl_FogFragCoord * gl_Fog.density);
-    fog.rgb = gl_Fog.color.rgb;
-
-    //Apply the fog.
-    col.rgb = mix(col.rgb, fog.rgb, fog.a);
+	//Apply fog
+	#include "/lib/fog.glsl"
 
     //Output the result.
     /*DRAWBUFFERS:03*/

--- a/shaders/gbuffers_clouds.fsh
+++ b/shaders/gbuffers_clouds.fsh
@@ -26,22 +26,8 @@ void main()
     //Sample texture times Visibility.
     vec4 col = color * vec4(light,1) * texture2D(texture,coord0);
 
-    //Calculate fog intensity in or out of water.
-    //vec4 fog = vec4(1);
-    //fog.a = gl_Fog.scale;
-    vec4 fog;
-    if(fogMode == GL_EXP)
-        fog.a = 1.-exp(-gl_FogFragCoord * gl_Fog.density);
-    else if (fogMode == GL_LINEAR)
-        fog.a = clamp((gl_FogFragCoord-gl_Fog.start) * gl_Fog.scale, 0., 1.);
-    else if (isEyeInWater == 1.0 || isEyeInWater == 2.0)
-        fog.a = 1.-exp(-gl_FogFragCoord * gl_Fog.density);
-    fog.rgb = gl_Fog.color.rgb;
-    //float fog = clamp((gl_FogFragCoord-gl_Fog.start) * gl_Fog.scale, 0., 1.);
-
-    //Apply the fog.
-    col.rgb = mix(col.rgb, fog.rgb, fog.a);
-
+	//Apply fog
+	#include "/lib/fog.glsl"
     //Output the result.
     /*DRAWBUFFERS:03*/
     gl_FragData[0] = col;

--- a/shaders/gbuffers_entities.fsh
+++ b/shaders/gbuffers_entities.fsh
@@ -23,27 +23,12 @@ const int GL_EXP = 2048;
 uniform int fogMode;
 
 void main() {
-	//vec4 col = texture2D(texture, texcoord) * color;
-	//col *= texture2D(lightmap, lmcoord);
 	vec3 light = (1.-blindness) * texture2D(lightmap,lmcoord).rgb;
 	vec4 col = color * vec4(light,1) * texture2D(texture,texcoord);
 	col.rgb = mix(col.rgb,entityColor.rgb,entityColor.a);
 
-	//vec3 col = color.rgb;
-
-    //Calculate fog intensity in or out of water.
-    vec4 fog;
-    if(fogMode == GL_EXP)
-        fog.a = 1.-exp(-gl_FogFragCoord * gl_Fog.density);
-    else if (fogMode == GL_LINEAR)
-        fog.a = clamp((gl_FogFragCoord-gl_Fog.start) * gl_Fog.scale, 0., 1.);
-    else if (isEyeInWater == 1.0 || isEyeInWater == 2.0)
-        fog.a = 1.-exp(-gl_FogFragCoord * gl_Fog.density);
-    fog.rgb = gl_Fog.color.rgb;
-
-    //fog = 1.0-fog;
-
-    col.rgb = mix(col.rgb, fog.rgb, fog.a);
+	//Apply fog
+    #include "/lib/fog.glsl"
 
 /* DRAWBUFFERS:0 */
 	gl_FragData[0] = col; //gcolor

--- a/shaders/gbuffers_skybasic.fsh
+++ b/shaders/gbuffers_skybasic.fsh
@@ -18,20 +18,8 @@ void main()
 {
     vec4 col = color;
 
-    //Calculate fog intensity in or out of water.
-    vec4 fog;
-    //fog = vec4(1);
-    //fog.a = gl_Fog.scale;
-    if(fogMode == GL_EXP)
-        fog.a = 1.-exp(-gl_FogFragCoord * gl_Fog.density);
-    else if (fogMode == GL_LINEAR)
-        fog.a = clamp((gl_FogFragCoord-gl_Fog.start) * gl_Fog.scale, 0., 1.);
-    else if (isEyeInWater == 1.0 || isEyeInWater == 2.0)
-        fog.a = 1.-exp(-gl_FogFragCoord * gl_Fog.density);
-    fog.rgb = gl_Fog.color.rgb;
-
-    //Apply the fog.
-    col.rgb = mix(col.rgb, fog.rgb, fog.a);
+	//Apply fog
+	#include "/lib/fog.glsl"
 
     //Output the result.
     /*DRAWBUFFERS:03*/

--- a/shaders/gbuffers_textured.fsh
+++ b/shaders/gbuffers_textured.fsh
@@ -39,25 +39,9 @@ void main()
     //Apply entity flashes.
     col.rgb = mix(col.rgb,entityColor.rgb,entityColor.a);
 
-    //Calculate fog intensity in or out of water.
-    vec4 fog;
-    //fog = vec4(1);
-    //fog.a = gl_Fog.scale;
-    if(fogMode == GL_EXP)
-        fog.a = 1.-exp(-gl_FogFragCoord * gl_Fog.density);
-    else if (fogMode == GL_LINEAR)
-        fog.a = clamp((gl_FogFragCoord-gl_Fog.start) * gl_Fog.scale, 0., 1.);
-    else if (isEyeInWater == 1.0 || isEyeInWater == 2.0)
-        fog.a = 1.-exp(-gl_FogFragCoord * gl_Fog.density);
+	//Apply fog
+    #include "/lib/fog.glsl"
 
-    //float fog = clamp((gl_FogFragCoord-gl_Fog.start) * gl_Fog.scale, 0., 1.);
-    fog.rgb = gl_Fog.color.rgb;
-
-
-    //fog = 1.0-fog;
-
-    //Apply the fog.
-	col.rgb = mix(col.rgb, fog.rgb, fog.a);
     //Output the result.
     /*DRAWBUFFERS:03*/
     gl_FragData[0] = col;

--- a/shaders/gbuffers_water.fsh
+++ b/shaders/gbuffers_water.fsh
@@ -33,24 +33,9 @@ void main()
     //Apply entity flashes.
     col.rgb = mix(col.rgb,entityColor.rgb,entityColor.a);
 
-    //Calculate fog intensity in or out of water.
-    vec4 fog;
-    //fog = vec4(1);
-    //fog.a = gl_Fog.scale;
-    if(fogMode == GL_EXP)
-        fog.a = 1.-exp(-gl_FogFragCoord * gl_Fog.density);
-    else if (fogMode == GL_LINEAR)
-        fog.a = clamp((gl_FogFragCoord-gl_Fog.start) * gl_Fog.scale, 0., 1.);
-    else if (isEyeInWater == 1.0 || isEyeInWater == 2.0)
-        fog.a = 1.-exp(-gl_FogFragCoord * gl_Fog.density);
+	//Apply fog
+    #include "/lib/fog.glsl"
 
-    //float fog = clamp((gl_FogFragCoord-gl_Fog.start) * gl_Fog.scale, 0., 1.);
-    fog.rgb = gl_Fog.color.rgb;
-
-    //fog = 1.0-fog;
-
-    //Apply the fog.
-	col.rgb = mix(col.rgb, fog.rgb, fog.a);
     //Output the result.
     /*DRAWBUFFERS:03*/
     gl_FragData[0] = col;

--- a/shaders/lib/fog.glsl
+++ b/shaders/lib/fog.glsl
@@ -1,0 +1,17 @@
+/*
+Only works in GBuffers
+Requires these things to be set before the main function:
+const int GL_LINEAR = 9729;
+const int GL_EXP = 2048;
+uniform int fogMode;
+*/
+vec4 fog;
+if(fogMode == GL_EXP) //exponential fog
+	fog.a = 1.-exp(-gl_FogFragCoord * gl_Fog.density);
+else if (fogMode == GL_LINEAR) //linear fog
+	fog.a = clamp((gl_FogFragCoord-gl_Fog.start) * gl_Fog.scale, 0., 1.);
+else if (isEyeInWater == 1.0 || isEyeInWater == 2.0)
+	fog.a = 1.-exp(-gl_FogFragCoord * gl_Fog.density); //denser underwater and underlava fog
+fog.rgb = gl_Fog.color.rgb;
+//Apply the fog.
+col.rgb = mix(col.rgb, fog.rgb, fog.a);


### PR DESCRIPTION
This PR moves the fog calculations that are currently spread out across multiple files to lib/fog.glsl, from where they are then included wherever they are used. This makes it easier to edit fog code because changes don't need to be manually duplicated multiple times.